### PR TITLE
Fix invalid release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 on: 
   release: 
+    types: [published, created]
 
   - uses: actions/package-action@1.0.1
     with:


### PR DESCRIPTION
Related to #62

Update the `release` workflow file to include a map value for the `release` event.

* Add `types: [published, created]` to the `release` event in `.github/workflows/release.yml`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/builtwithai/askgpt/issues/62?shareId=e7f83b68-2641-4fa8-bf33-31e18e9292bf).